### PR TITLE
adding string[] and RegExp support to filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@
 ## useBus
 `import useBus from 'use-bus'`:
 - `useBus(filter, callback, deps)`: register the given `callback` to the given `filter`
-  * `filter`: it can be a string or a function
+  * `filter`: it can be a string, array of strings, RegExp or a function
     - `string`: if filter is a string, then the action type is test over this given string, **if the filter match the type, the callback is called**
+    - `string[]`: **if the filter array includes the type, the callback is called**
+    - `RegExp`: **if the filter expression matches the type, the callback is called** 
     - `function`: **the callback is called if the function returns a truthy value**
   * `callback`: take the action as the first argument so you can retrieve its type and its payload for example
   * `deps`: is an array where you declare variables you use in `callback`, like you are doing for a useEffect from React

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,5 +8,7 @@ declare module "use-bus" {
   export function dispatch(event: EventAction): void;
 
   export default function useBus(name: string, callback: (event: EventAction) => void, deps: any[]): typeof dispatch;
+  export default function useBus(name: string[], callback: (event: EventAction) => void, deps: any[]): typeof dispatch;
+  export default function useBus(name: RegExp, callback: (event: EventAction) => void, deps: any[]): typeof dispatch;
   export default function useBus(filter: (event: EventAction) => boolean, callback: (event: EventAction) => void, deps: any[]): typeof dispatch;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,8 @@ export const dispatch = (event) => {
 
   subscribers.forEach(([filter, callback]) => {
     if (typeof filter === 'string' && filter !== type) return
+    if (Array.isArray(filter) && !filter.includes(type)) return
+    if (filter instanceof RegExp && !filter.test(type)) return
     if (typeof filter === 'function' && !filter(...args)) return
 
     callback(...args)

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -89,3 +89,91 @@ it('should register a function and call the callback', (done) => {
 
   done()
 })
+
+it('should register an array and call the callback', (done) => {
+  let hitCount = 0
+  let missCount = 0
+
+  const { unmount: unmountHit } = renderHook(() => useBus(['foo', 'bar'], (event) => {
+    hitCount += 1
+    expect(event).toEqual({
+      channel: 'ui',
+      type: expect.stringMatching(/^(foo|bar)$/),
+      payload: 'some payload',
+    })
+  }))
+
+  const { unmount: unmountMiss } = renderHook(() => useBus(['baz'], () => {
+    missCount += 1
+  }))
+
+  dispatch({
+    channel: 'ui',
+    type: 'foo',
+    payload: 'some payload',
+  })
+
+  dispatch({
+    channel: 'ui',
+    type: 'bar',
+    payload: 'some payload',
+  })
+
+  dispatch({
+    channel: 'ui',
+    type: 'baz',
+    payload: 'some payload',
+  })
+
+  unmountHit()
+  unmountMiss()
+
+  expect(hitCount).toEqual(2)
+  expect(missCount).toEqual(1)
+
+  done()
+})
+
+it('should register a RegExp and call the callback', (done) => {
+  let hitCount = 0
+  let missCount = 0
+
+  const { unmount: unmountHit } = renderHook(() => useBus(/^b/, (event) => {
+    hitCount += 1
+    expect(event).toEqual({
+      channel: 'ui',
+      type: expect.stringMatching(/^(bar|baz)$/),
+      payload: 'some payload',
+    })
+  }))
+
+  const { unmount: unmountMiss } = renderHook(() => useBus(/^f/, () => {
+    missCount += 1
+  }))
+
+  dispatch({
+    channel: 'ui',
+    type: 'foo',
+    payload: 'some payload',
+  })
+
+  dispatch({
+    channel: 'ui',
+    type: 'bar',
+    payload: 'some payload',
+  })
+
+  dispatch({
+    channel: 'ui',
+    type: 'baz',
+    payload: 'some payload',
+  })
+
+  unmountHit()
+  unmountMiss()
+
+  expect(hitCount).toEqual(2)
+  expect(missCount).toEqual(1)
+
+  done()
+})


### PR DESCRIPTION
Resolving issue #1 and #2 , this PR adds support for both `string[]` and `RegExp` filter parameters to `useBus()`.