### PR TITLE
considering strongly-typed bus events.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,43 +1,50 @@
 import { useEffect } from 'react'
 
-let subscribers = []
+export const createBus = () => {
+  let subscribers = []
 
-const subscribe = (filter, callback) => {
-  if (filter === undefined || filter === null) return undefined
-  if (callback === undefined || callback === null) return undefined
+  const subscribe = (filter, callback) => {
+    if (filter === undefined || filter === null) return undefined
+    if (callback === undefined || callback === null) return undefined
 
-  subscribers = [
-    ...subscribers,
-    [filter, callback],
-  ]
+    subscribers = [
+      ...subscribers,
+      [filter, callback],
+    ]
 
-  return () => {
-    subscribers = subscribers.filter((subscriber) => subscriber[1] !== callback)
+    return () => {
+      subscribers = subscribers.filter((subscriber) => subscriber[1] !== callback)
+    }
   }
+
+  const dispatch = (event) => {
+    let { type } = event
+    if (typeof event === 'string') type = event
+
+    const args = []
+    if (typeof event === 'string') args.push({ type })
+    else args.push(event)
+
+    subscribers.forEach(([filter, callback]) => {
+      if (typeof filter === 'string' && filter !== type) return
+      if (Array.isArray(filter) && !filter.includes(type)) return
+      if (filter instanceof RegExp && !filter.test(type)) return
+      if (typeof filter === 'function' && !filter(...args)) return
+
+      callback(...args)
+    })
+  }
+
+  const useBus = (type, callback, deps = []) => {
+    useEffect(() => subscribe(type, callback), deps)
+
+    return dispatch
+  }
+
+  return [useBus, dispatch]
 }
 
-export const dispatch = (event) => {
-  let { type } = event
-  if (typeof event === 'string') type = event
+const [useBus, dispatch] = createBus();
 
-  const args = []
-  if (typeof event === 'string') args.push({ type })
-  else args.push(event)
-
-  subscribers.forEach(([filter, callback]) => {
-    if (typeof filter === 'string' && filter !== type) return
-    if (Array.isArray(filter) && !filter.includes(type)) return
-    if (filter instanceof RegExp && !filter.test(type)) return
-    if (typeof filter === 'function' && !filter(...args)) return
-
-    callback(...args)
-  })
-}
-
-const useBus = (type, callback, deps = []) => {
-  useEffect(() => subscribe(type, callback), deps)
-
-  return dispatch
-}
-
+export { dispatch }
 export default useBus


### PR DESCRIPTION
A PR candidate to introduce a _new feature_ `createBus()` and an extension to the typescript definitions to allow _strong-typed_ buses and event filtering. 

### Custom bus with `createBus()`

`createBus()` creates an independent bus or channel that can be used _independently_ of the _global_ exported `useBus` and `dispatch()` methods. Usage:

```ts
import { createBus } from 'use-bus';

const [useMyBus, myDispatch] = createBus();
```

### Strongly typed buses with `createBus()`

`createBus()` also accepts a generic, which can be used to constrain handler callbacks to strongly-typed event callbacks. Consider:

```ts 
type BusEvents = 
  |  { type: '@@ui/ADD_ITERATION', duration: string } 
  |  { type: '@@ui/DELETE_ITERATION', idx: number };

const [useBus, dispatch] = createBus<BusEvents>();

useBus('@@ui/ADD_ITERATION', (event) => {
  console.log(event.duration);
}, []);

useBus('@@ui/DELETE_ITERATION', (event) => {
  console.log(event.idx);
}, []);
```

In the above example, `event.duration` and `event.idx` in their handlers will be strongly-typed.

This also works for _type predicates_ as filters functions:

```ts 
type UIEvents = 
  |  { type: '@@ui/ADD_ITERATION', duration: string } 
  |  { type: '@@ui/DELETE_ITERATION', idx: number };

type DBEvents = 
  |  { type: '@@db/SYNC' } 

type BusEvents = UIEvents | DBEvents;

const isUIEvent = (e: BusEvent): e is UIEvent => e.type.startsWith('@@ui');

const [useBus, dispatch] = createBus<BusEvents>();

useBus(isUIEvent, (event: UIEvents) => {
  /* do work here */
}, []);
```

### Backwards compatibility

The top-level `useBus` and `dispatch` global bus still works the same way as it did before, with a similar type contract for event type shapes.

### Possible issues/concerns

- `createBus()` supports the same `dispatch(string)` signature, which would mean that the types on the `useBus()` handler side might be _entirely_ accurate; missing some fields. There might be a way to constrain that particular helper to _only_ support the short-hand helper when `type` is the _only_ field defined in the event payload.