### PR TITLE
fix ts syntax tip when registering an event with `useBus` without passing in deps

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,8 +7,8 @@ declare module "use-bus" {
   export function dispatch(name: string): void;
   export function dispatch(event: EventAction): void;
 
-  export default function useBus(name: string, callback: (event: EventAction) => void, deps: any[]): typeof dispatch;
-  export default function useBus(name: string[], callback: (event: EventAction) => void, deps: any[]): typeof dispatch;
-  export default function useBus(name: RegExp, callback: (event: EventAction) => void, deps: any[]): typeof dispatch;
-  export default function useBus(filter: (event: EventAction) => boolean, callback: (event: EventAction) => void, deps: any[]): typeof dispatch;
+  export default function useBus(name: string, callback: (event: EventAction) => void, deps?: any[]): typeof dispatch;
+  export default function useBus(name: string[], callback: (event: EventAction) => void, deps?: any[]): typeof dispatch;
+  export default function useBus(name: RegExp, callback: (event: EventAction) => void, deps?: any[]): typeof dispatch;
+  export default function useBus(filter: (event: EventAction) => boolean, callback: (event: EventAction) => void, deps?: any[]): typeof dispatch;
 }


### PR DESCRIPTION
When I use `useBus` to register events without pass deps, the ts syntax tip will error.
Like this:
```
useBus(
    'ADD_PREVIEW_STYLE',
    ({ type, payload }) => {
      // do something
    }
  )
```
Uh, I see deps default is a null array in the index.js, but in the index.d.ts deps is must be passed in.
So I modify it as an optional parameter.